### PR TITLE
fix : exampleの表記ミスを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install ikku
 Reviewer is the main interface for this library.
 
 ```python
-from ikku import Reviwer
+from ikku import Reviewer
 reviewer = Reviewer()
 ```
 


### PR DESCRIPTION
```py
from ikku import reviwer
```
↓
```py
from ikku import reviewer
```